### PR TITLE
Feature/metafox 106 rte

### DIFF
--- a/blocks/icon-link-list/icon-link-list.js
+++ b/blocks/icon-link-list/icon-link-list.js
@@ -12,12 +12,13 @@ export default function decorate(block) {
     // generate the  panel
     const [iconType, ...rest] = panel.children;
     const classesText = iconType.textContent.trim();
-    const iconDOM = generateIconDOM([iconType, ...rest]);
-
-    panel.textContent = '';
-    panel.classList.add('icon', 'block', classesText);
-    panel.append(iconDOM);
-    panelContainer.append(panel);
+    if (classesText) {
+      const iconDOM = generateIconDOM([iconType, ...rest]);
+      panel.textContent = '';
+      panel.classList.add('icon', 'block', classesText);
+      panel.append(iconDOM);
+      panelContainer.append(panel);
+    }
   });
   block.textContent = '';
   block.append(panelContainer);

--- a/component-filters.json
+++ b/component-filters.json
@@ -72,7 +72,7 @@
       "list": ["bullist", "numlist"],
       "insert": ["link"],
       "blocks": [],
-      "advanced": [],
+      "advanced": ["h3"],
       "extensions": [],
       "editor": ["removeformat"]
     }

--- a/component-models.json
+++ b/component-models.json
@@ -50,7 +50,7 @@
       {
         "component": "text-input",
         "valueType": "string",
-        "name": "Copyright",
+        "name": "copyright",
         "value": "",
         "label": "Text",
         "required": true
@@ -325,26 +325,7 @@
   },
   {
     "id": "footer-section",
-    "fields": [
-      {
-        "id": "link_count",
-        "fields": [
-          {
-            "component": "number",
-            "valueType": "number",
-            "name": "link_count",
-            "label": "No of Links",
-            "description": "This is a number field.",
-            "required": true,
-            "placeholder": null,
-            "validation": {
-              "numberMin": 1,
-              "numberMax": 10,
-              "customErrorMsg": "Please enter a no. between 1 & 10 (both inclusive) only"
-            }
-          }
-        ]
-      },
+    "fields": [      
       {
         "component": "radio-group",
         "label": "Background Color",


### PR DESCRIPTION
This PR contains fixes for below : 
-Copyright not appearing under foot-section fixes
-Not able to restricts blocks inside footer-section fixes
-console error while adding icon in author page under icon link list block fixes
-checking whether we will be able to restrict "h3" tag under copytext


Test URLs:
-https://feature-metafox-106-rte--metafox-sites--bmw-importer.hlx.page/index/text-testpage
