### PR TITLE
Feature/metafox 28 header flyout

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -712,6 +712,7 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     display: flex;
     justify-content: center;
     align-items: center;
+
     /* max-height: calc(100vh - 69px); */
     overflow: hidden;
     position: absolute;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -468,6 +468,39 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     color: var(--background-color);
     font-weight: 400;
   }
+
+  header nav[aria-expanded="false"] .menu-flyout-wrapper {
+    display: none;
+}
+
+header nav[aria-expanded="true"] .menu-flyout-wrapper .flyout-wrapper {
+    display: none;
+}
+
+header nav[aria-expanded="true"] .menu-flyout-wrapper::after {       
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-feature-settings: "liga";
+    content: " arrow_chevron_right";
+    direction: ltr;
+    display: block;
+    font-family: "bmw_next_icons", arial,helvetica,roboto,sans-serif;
+    font-style: normal;
+    height: 1em;
+    line-height: 1;
+    outline: 1px solid transparent;
+    text-align: left;
+    text-rendering: optimizelegibility;
+    text-transform: none;
+    white-space: nowrap;
+    width: auto;
+    font-size: 1.25rem;
+    color: var(--light-border-color);
+    font-weight: 400;
+    position: absolute;
+    right: 50px;
+    top: 12px;
+}
   
 }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -705,18 +705,20 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
    top: 80px;
    display: none;
    padding: 3.125rem 0;
+   transition: top 0.65s ease;
   }
 
   .showfly .flyout-main-container {
     display: flex;
     justify-content: center;
     align-items: center;
-    max-height: calc(100vh - 69px);
+    /* max-height: calc(100vh - 69px); */
     overflow: hidden;
     position: absolute;
     top: 5.25rem;
     width: 100vw;
     left: -6rem;
+    transition: top 0.65s ease;
   }
 
 }

--- a/blocks/link-list/link-list.css
+++ b/blocks/link-list/link-list.css
@@ -157,6 +157,41 @@ footer .link-list-wrapper.vertical .link-list-detail ul li a:hover{
     footer .link-list-wrapper.horizontal .link-list-title {
         display: block;
     }
+   
+    header nav[aria-expanded="false"] .menu-flyout-wrapper {
+        display: none;
+    }
+    
+    header nav[aria-expanded="true"] .menu-flyout-wrapper .flyout-wrapper {
+        display: none;
+    }
+
+    header nav[aria-expanded="true"] .menu-flyout-wrapper::after {       
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        font-feature-settings: "liga";
+        content: " arrow_chevron_right";
+        direction: ltr;
+        display: block;
+        font-family: "bmw_next_icons", arial,helvetica,roboto,sans-serif;
+        font-style: normal;
+        height: 1em;
+        line-height: 1;
+        outline: 1px solid transparent;
+        text-align: left;
+        text-rendering: optimizelegibility;
+        text-transform: none;
+        white-space: nowrap;
+        width: auto;
+        font-size: 1.25rem;
+        color: var(--light-border-color);
+        font-weight: 400;
+        position: absolute;
+        right: 50px;
+        top: 12px;
+    }
+    
+
 }
 
 /* tablet */
@@ -202,3 +237,5 @@ footer .link-list-wrapper.vertical .link-list-detail ul li a:hover{
         margin-bottom: 0.75rem;
     }    
 }
+
+/* header link list css */ 


### PR DESCRIPTION
fixes:
For mobile and ipad we have removed the unwanted text.

Test URLs:
- Before: https://main--metafox-sites--bmw-importer.hlx.page/
- After: https://feature-metafox-28-header-flyout--metafox-sites--bmw-importer.hlx.page/
