### PR TITLE
Feature/metafox 28 header

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -186,16 +186,16 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     line-height: 24px;
   }
 
+  header nav .section ul, header nav .section p {
+    width: 83.3333%;
+    margin: 0 auto;
+  }
+
   header nav[aria-expanded="true"] .menu-flyout-wrapper .menu-flyout.block p{
     margin: 0;
     width: 100%;
   }
 
-  header nav .section ul, header nav .section p {
-    width: 83.3333%;
-    margin: 0 auto;
-  }
- 
   .header nav .section .default-content-wrapper {
     padding: 1.75rem 1.5rem 0;
   }
@@ -304,6 +304,11 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     overflow-y: scroll;
     
   }
+  
+  header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .flyout-main-container {   
+    width: 100%;
+    position: relative;
+  }
 
   header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .flyout-wrapper .flyout-main-container {
    padding: 1rem 2.5rem;
@@ -360,11 +365,6 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     position: absolute;
     right: 2.5rem;
    }
-
-   header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .flyout-main-container {   
-    width: 100%;
-    position: relative;
-  }
 
   header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout .flyout-main-container .flyout-link-list {
     padding: 0.75rem;
@@ -849,14 +849,15 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .
 
   
 }
-/*ipad pro*/
 
+/* ipad pro */
 @media (width >= 830px) and (width < 1280px) {
   header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .link-list-wrapper.vertical .link-list-title::after{
     display: none;
     content: " ";
   }
 }
+
 /* Desktop  */
 @media (width >= 1280px) { 
   header nav {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -448,6 +448,7 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
   }
 
   header nav[aria-expanded="true"] {
+    display: block;
     min-height: 100vh;
     align-items: baseline;
     background: var(--background-color);
@@ -494,6 +495,8 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     padding: .55rem 7rem;
     font-weight: 700;
     color: var(--light-border-color);
+    cursor: pointer;
+    text-decoration: none;
   }
 
   header nav[aria-expanded="true"] .menu-link-wrapper a {
@@ -652,7 +655,6 @@ header nav[aria-expanded="true"] .menu-flyout-wrapper::after {
 }
 
 /* flyout css ipad code */ 
- 
 header nav[aria-expanded="true"] .nav-brand.mobile-flyout > .menu-link-wrapper {
   display: none;
 }
@@ -660,14 +662,20 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout > .menu-link-wrapper {
 header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .flyout-wrapper {
  display: flex;
  border-top: 1px solid var(--light-bbb);
- padding: .5rem 2.5rem;
+ padding: 1rem 5.5rem;
+ position: sticky;
+  top: 0;
+  height: auto;
+  overflow-y: scroll;
+  
 }
 
 header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly {
   position: static;
-  margin-top: 70px;
+  margin-top: 5.7rem;
   border-top: 1px solid var(--light-bbb);
   padding: 0;
+  display: block;
  }
 
  header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly::after {
@@ -680,35 +688,44 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.s
   font-weight: 700;
   text-transform: capitalize;
   display: flex;
+  cursor: pointer;
+  letter-spacing: 0;
 }
 
-header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .link-list-wrapper.vertical .link-list-title :hover{
-  color: var(--link-color);
+
+header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .link-list-wrapper.vertical .link-list-title:hover {
+  color: var(--link-hover-color);
 }
 
 header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .link-list-wrapper.vertical .link-list-title::after {
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
-      font-feature-settings: "liga";
-      content: "arrow_chevron_down";
-      direction: ltr;
-      display: block;
-      font-family: var(--icon-font-family);
-      font-size: 1.5rem;
-      font-style: normal;
-      font-weight: 400;
-      height: 1em;
-      line-height: 1;
-      outline: 1px solid transparent;
-      text-align: left;
-      text-rendering: optimizelegibility;
-      text-transform: none;
-      white-space: nowrap;
-      width: auto;
-      position: relative;
-      top: -7px;
-      left: 60px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "liga";
+  content: "arrow_chevron_down";
+  direction: ltr;
+  display: block;
+  font-family: "bmw_next_icons", arial, helvetica, roboto, sans-serif;
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 400;
+  height: 1em;
+  line-height: 1;
+  transform: translate(25%, -50%);
+  transition: transform .5s ease-in-out;
+  outline: 1px solid transparent;
+  text-align: left;
+  text-rendering: optimizelegibility;
+  text-transform: none;
+  white-space: nowrap;
+  width: auto;
+  position: absolute;
+  right: 0;
  }
+
+ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .flyout-main-container {   
+  width: 100%;
+  position: relative;
+}
 
 header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout .flyout-main-container .flyout-link-list {
   padding: 0.75rem;
@@ -716,6 +733,18 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout .flyout-m
   margin: 0 auto;
   font-size: .875rem;
   font-weight: 700;
+}
+
+header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout .flyout-main-container .flyout-link-list .link-list .link-list-detail {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height .25s ease;
+  margin-left: 1.5rem;
+}
+
+header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .flyout-link-list .link-list .link-list-title.expand::after{
+  transform: translate(25%, -50%) rotate(-180deg);
+  color: var(--light-link-color);
 }
 
 header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .menu-flyout.block span {
@@ -732,15 +761,36 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.s
   content: "arrow_chevron_left";
   direction: ltr;
   display: block;
-  font-family: var(--icon-font-family);
+  font-family: "bmw_next_icons", arial, helvetica, roboto, sans-serif;
   font-size: 1.25rem;
   font-style: normal;
   font-weight: 400;
   height: 1em;
   line-height: 1;
-  position: relative;
-  left: -5rem;
+  position: absolute;
+  left: 2.5rem;
 }
+
+header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .menu-teaser-image p {
+  width: 100%;
+}
+
+header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .menu-teaser-image p img {
+  width: 100%;
+}
+
+header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .menu-flyout .flyout-main-container .flyout-menu-teaser {
+  width: 100%;
+}
+
+header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper {
+  display: none;
+}
+
+header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .copy-text{
+ margin-bottom: 1rem;
+}
+
   
 }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -298,7 +298,6 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
   header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .flyout-wrapper {
    display: flex;
    border-top: 1px solid var(--light-bbb);
-   padding: 1rem 2.5rem;
    position: sticky;
     top: 0;
     height: 425px;
@@ -306,6 +305,10 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     
   }
 
+  header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .flyout-wrapper .flyout-main-container {
+   padding: 1rem 2.5rem;
+  }
+  
   header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly {
     position: static;
     margin-top: 70px;
@@ -355,7 +358,7 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     white-space: nowrap;
     width: auto;
     position: absolute;
-    right: 1rem;
+    right: 2.5rem;
    }
 
    header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .flyout-main-container {   
@@ -679,6 +682,17 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.s
   
 }
 
+header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .flyout-wrapper.bmw-info{
+  display: flex;
+  border-top: 1px solid var(--light-bbb);
+  padding: 0;
+  position: sticky;
+  top: 0;
+  height: auto;
+  overflow-y: scroll;
+   
+ }
+
 header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly {
   position: static;
   margin-top: 5.7rem;
@@ -692,13 +706,15 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.s
  }
 
 header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .link-list-wrapper.vertical .link-list-title {
-  color: var(--light-text-color);
-  font-size: 14px;
-  font-weight: 700;
-  text-transform: capitalize;
-  display: flex;
-  cursor: pointer;
-  letter-spacing: 0;
+  padding-right: 0;
+  margin: 0 0 1rem;
+  color: var(--medium-text-color);
+  font-size: 0.625rem;
+  font-weight: 300;
+  line-height: 0.75rem;
+  letter-spacing: 0.125rem;
+  word-break: break-all;
+  text-transform: uppercase;
 }
 
 
@@ -711,6 +727,31 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.s
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: "liga";
   content: "arrow_chevron_down";
+  direction: ltr;
+  display: block;
+  font-family: "bmw_next_icons", arial, helvetica, roboto, sans-serif;
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 400;
+  height: 1em;
+  line-height: 1;
+  transform: translate(25%, -50%);
+  transition: transform .5s ease-in-out;
+  outline: 1px solid transparent;
+  text-align: left;
+  text-rendering: optimizelegibility;
+  text-transform: none;
+  white-space: nowrap;
+  width: auto;
+  position: absolute;
+  right: 0;
+ }
+
+ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .flyout-wrapper.bmw-info .link-list-wrapper.vertical .link-list-title::after {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "liga";
+  content: " ";
   direction: ltr;
   display: block;
   font-family: "bmw_next_icons", arial, helvetica, roboto, sans-serif;
@@ -749,6 +790,12 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout .flyout-m
   overflow: hidden;
   transition: max-height .25s ease;
   margin-left: 1.5rem;
+}
+
+header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container .flyout-link-list .link-list .link-list-detail {
+  display: block;
+  max-height: unset;
+  margin-left: 0;
 }
 
 header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .flyout-link-list .link-list .link-list-title.expand::after{
@@ -802,7 +849,14 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .
 
   
 }
+/*ipad pro*/
 
+@media (width >= 830px) and (width < 1280px) {
+  header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .link-list-wrapper.vertical .link-list-title::after{
+    display: none;
+    content: " ";
+  }
+}
 /* Desktop  */
 @media (width >= 1280px) { 
   header nav {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1,13 +1,10 @@
 /* header and nav layout */
+
 .content-page {
   overflow-y: hidden;
   width: 100%;
   position: fixed;
   top: 0;
-}
-
-header .menu-flyout-wrapper {
-  display: none;
 }
 
 header {
@@ -323,10 +320,12 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     text-transform: capitalize;
     display: flex;
     cursor: pointer;
+    letter-spacing: 0;
   }
 
-  header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .link-list-wrapper.vertical .link-list-title :hover{
-    color: var(--link-color);
+
+  header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .link-list-wrapper.vertical .link-list-title:hover {
+    color: var(--link-hover-color);
   }
 
   header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .link-list-wrapper.vertical .link-list-title::after {
@@ -351,7 +350,6 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     white-space: nowrap;
     width: auto;
     position: absolute;
-    top: 1.2rem;
     right: 1rem;
    }
 
@@ -372,6 +370,7 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
     max-height: 0;
     overflow: hidden;
     transition: max-height .25s ease;
+    margin-left: 1.5rem;
   }
 
   header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.showfly .flyout-link-list .link-list .link-list-title.expand::after{
@@ -747,6 +746,7 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper.s
 
 /* Desktop  */
 @media (width >= 1280px) { 
+
   header nav {
     display: flex;
     justify-content: space-between;

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -23,13 +23,22 @@ function closeOnEscape(e) {
 
 function handleHeaderLinkList(e) {
   const { target } = e;
-  if (!isDesktop.matches) {
+  if (window.innerWidth < 768) {
     if (target.classList.contains('expand')) {
       target.nextElementSibling.style.maxHeight = null;
       target.classList.remove('expand');
     } else {
-      target.nextElementSibling.style.maxHeight = `${target.nextElementSibling.scrollHeight}px`;
-      target.classList.add('expand');
+      let listOfTitle;
+      const parentElem = e.target.closest('.flyout-main-container');
+      if (parentElem) {
+        listOfTitle = parentElem.querySelectorAll('.link-list-wrapper.vertical .link-list-title.expand');
+        for (let j = 0; j < listOfTitle.length; j += 1) {
+          listOfTitle[j].classList.remove('expand');
+          listOfTitle[j].nextElementSibling.style.maxHeight = null;
+        }
+        target.nextElementSibling.style.maxHeight = `${target.nextElementSibling.scrollHeight}px`;
+        target.classList.add('expand');
+      }
     }
   }
 }
@@ -67,6 +76,12 @@ function toggleAllNavSections(sections, expanded = false) {
  * @param {Element} navSections The nav sections within the container element
  * @param {*} forceExpanded Optional param to force nav expand behavior when not null
  */
+
+function resetFlyoutNavSection() {
+  const navBrandSelector = document.querySelector('.nav-brand');
+  navBrandSelector?.classList.remove('mobile-flyout');
+}
+
 function toggleMenu(nav, navSections, forceExpanded = null) {
   const expanded = forceExpanded !== null ? !forceExpanded : nav.getAttribute('aria-expanded') === 'true';
   const button = nav.querySelector('.nav-hamburger button');
@@ -99,6 +114,7 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
     // collapse menu on escape press
     window.addEventListener('keydown', closeOnEscape);
   } else {
+    resetFlyoutNavSection();
     window.removeEventListener('keydown', closeOnEscape);
   }
 }

--- a/blocks/menu-flyout/menu-flyout.css
+++ b/blocks/menu-flyout/menu-flyout.css
@@ -148,8 +148,13 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .flyout-wrapper.bmw-info .
  flex: 0 0 20%
 }
 
-/*ipad mini and ipad air*/
+/* ipad mini and ipad air */
 @media (width >= 768px) and (width < 1280px) {
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-link-list, 
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-menu-teaser{
+        width: 100%;
+    }
+    
     header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container .container-link-list {
         width: 50%;  
     }
@@ -161,12 +166,8 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .flyout-wrapper.bmw-info .
         row-gap:0;
         padding: 1rem 3rem;
     }
-
-    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-link-list, 
-    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-menu-teaser{
-        width: 100%;
-    }
 }
+
 /* ipad pro */
 @media (width >= 830px) and (width < 1280px) {
     header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-link-list,
@@ -179,10 +180,11 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .flyout-wrapper.bmw-info .
         margin-left: 0;
     }
 
-    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container .container-link-list {
-        width: 25%;  
-    }
 
+    header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .flyout-main-container {
+        display: flex;
+    }
+    
     header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container {
         display: flex;
         flex-wrap: wrap;
@@ -190,12 +192,11 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .flyout-wrapper.bmw-info .
         row-gap:0;
         padding: 1rem 3rem;
     }
-    header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .flyout-main-container {
-        display: flex;
-    }
+
+   
 }
 
-/*mobile*/
+/* mobile */
 @media (width < 768px) {
     header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .flyout-menu-teaser {
         padding: 0;

--- a/blocks/menu-flyout/menu-flyout.css
+++ b/blocks/menu-flyout/menu-flyout.css
@@ -128,10 +128,11 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .link-list-wrapper.vertica
 
 header.header-wrapper .nav-brand .menu-flyout-wrapper .flyout-wrapper.bmw-info .flyout-main-container{
     flex-wrap: wrap;
-    height: 400px;
+    height: auto;
     overflow-y: auto;
     align-items: revert;
     row-gap: 4rem;
+    max-height: calc(100vh - 149px);
 }
 
 header.header-wrapper .nav-brand .menu-flyout-wrapper .flyout-wrapper.bmw-info .flyout-main-container .flyout-link-list {

--- a/blocks/menu-flyout/menu-flyout.css
+++ b/blocks/menu-flyout/menu-flyout.css
@@ -148,15 +148,59 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .flyout-wrapper.bmw-info .
  flex: 0 0 20%
 }
 
+/*ipad mini and ipad air*/
 @media (width >= 768px) and (width < 1280px) {
-    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-link-list, 
-    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-menu-teaser,
     header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container .container-link-list {
-        width: 100%;  
+        width: 50%;  
+    }
+
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0;
+        row-gap:0;
+        padding: 1rem 3rem;
+    }
+
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-link-list, 
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-menu-teaser{
+        width: 100%;
+    }
+}
+/* ipad pro */
+@media (width >= 830px) and (width < 1280px) {
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-link-list,
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-menu-teaser {
+        width: 50%;
+    }
+
+    header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout .flyout-main-container .flyout-link-list .link-list .link-list-detail{
+        overflow: unset;
+        margin-left: 0;
+    }
+
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container .container-link-list {
+        width: 25%;  
+    }
+
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0;
+        row-gap:0;
+        padding: 1rem 3rem;
+    }
+    header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .flyout-main-container {
+        display: flex;
     }
 }
 
+/*mobile*/
 @media (width < 768px) {
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .flyout-menu-teaser {
+        padding: 0;
+    }
+
     header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-link-list, 
     header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-menu-teaser,
     header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container .container-link-list {

--- a/blocks/menu-flyout/menu-flyout.css
+++ b/blocks/menu-flyout/menu-flyout.css
@@ -1,7 +1,6 @@
 /* menu-flyout css */
 
 header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .flyout-link-list {
-    order: 1;
     margin-left: 25%;
     display: block;
     width: 50%;
@@ -9,7 +8,6 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-
 }
 
 header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .flyout-menu-teaser {
-    order: 2;
     margin-right: 25%;
     display: block;
     width: 50%;
@@ -124,4 +122,19 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .link-list-wrapper.vertica
 
 .flyout-menu-teaser p {
     margin: 0;
+}
+
+/* BMW info tab css */
+
+header.header-wrapper .nav-brand .menu-flyout-wrapper .flyout-wrapper.bmw-info .flyout-main-container{
+    flex-wrap: wrap;
+    height: 400px;
+    overflow-y: auto;
+    align-items: revert;
+    row-gap: 4rem;
+}
+
+header.header-wrapper .nav-brand .menu-flyout-wrapper .flyout-wrapper.bmw-info .flyout-main-container .flyout-link-list {
+ margin-left: 0;
+ flex: 0 0 20%
 }

--- a/blocks/menu-flyout/menu-flyout.css
+++ b/blocks/menu-flyout/menu-flyout.css
@@ -180,6 +180,9 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .flyout-wrapper.bmw-info .
         margin-left: 0;
     }
 
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container .container-link-list {
+        width: 25%;  
+    }
 
     header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .flyout-main-container {
         display: flex;

--- a/blocks/menu-flyout/menu-flyout.js
+++ b/blocks/menu-flyout/menu-flyout.js
@@ -1,5 +1,3 @@
-/*
-
 import { generateMenuTeaserDOM } from '../menu-teaser/menu-teaser.js';
 import { generateHeaderLinkList } from '../link-list/link-list.js';
 
@@ -7,9 +5,9 @@ export function generateMenuFlyoutLink(props) {
   const [menuflyoutText] = props;
   const menuFlyoutLinkDOM = document.createRange().createContextualFragment(`
     <span id="${menuflyoutText.textContent}"
- class="${menuflyoutText.textContent} menu-flyout-link">
-      ${menuflyoutText.textContent}
-    </span>
+      class="${menuflyoutText.textContent} menu-flyout-link">
+            ${menuflyoutText.textContent}
+          </span>
   `);
   return menuFlyoutLinkDOM;
 }
@@ -48,9 +46,9 @@ export default function decorate(block) {
   });
   const flyoutWrapperDiv = document.createElement('div');
   flyoutWrapperDiv.classList.add('flyout-wrapper');
-
+  const menuPropsText = menuProps[0].textContent;
+  const sanitizedClassName = menuPropsText.replace(/\s+/g, '-'); // Replace spaces with hyphens
+  flyoutWrapperDiv.classList.add(sanitizedClassName.toLowerCase());
   flyoutWrapperDiv.appendChild(wrapperDiv);
   block.appendChild(flyoutWrapperDiv);
 }
-
-*/


### PR DESCRIPTION
fixes: 
Desktop, ipad, mobile header flyout.
<img width="942" alt="desktop" src="https://github.com/BMW-Importer/metafox-sites/assets/159911559/47d49c2f-7bbc-4666-8c8a-381471b596e1">
<img width="383" alt="ipad_mini" src="https://github.com/BMW-Importer/metafox-sites/assets/159911559/de77e57d-7086-4d03-95f1-168ccd2ef5ad">
<img width="523" alt="ipad_pro" src="https://github.com/BMW-Importer/metafox-sites/assets/159911559/35abfb71-8457-43b9-906e-d77bfe5c4a07">
<img width="533" alt="ipad_prop" src="https://github.com/BMW-Importer/metafox-sites/assets/159911559/3562167d-949e-43eb-b2a2-b776bebde611">


Test URLs:
- Before: https://main--metafox-sites--bmw-importer.hlx.page/
- After:  https://feature-metafox-28-header--metafox-sites--bmw-importer.hlx.page/
