### PR TITLE
defects fixes

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -299,10 +299,9 @@ header.white-background .nav-wrapper .logo-wrapper .grey-image {
    display: flex;
    border-top: 1px solid var(--light-bbb);
    position: sticky;
-    top: 0;
-    height: 425px;
-    overflow-y: scroll;
-    
+   top: 0;
+   height: auto;
+   overflow-y: scroll;    
   }
   
   header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .flyout-main-container {   

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -205,7 +205,7 @@ export default async function decorate(block) {
       parentMenu.classList.toggle('showfly', !isOpen);
       mainParentMenu.classList.toggle('mobile-flyout', !isOpen);
       bodyContent.classList.toggle('content-page', !isOpen);
-      if (headerType && headerType === 'whitebackground' && event.target.parentNode.parentElement.classList.contains('showfly')) {
+      if (headerType && headerType === 'whitebackground' && event.target.parentNode.parentElement.parentElement.classList.contains('showfly')) {
         header[0].classList.remove('white-background');
         header[0].classList.add('transparent');
       } else {

--- a/blocks/menu-flyout/menu-flyout.css
+++ b/blocks/menu-flyout/menu-flyout.css
@@ -165,6 +165,12 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper:nth-last-child(2) .flyout-
         row-gap:0;
         padding: 1rem 3rem;
     }
+
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .flyout-menu-teaser .menu-teaser-image picture,
+    header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .flyout-menu-teaser .menu-teaser-image img {
+    width: 100%;
+    height: 19.5rem;
+    }
 }
 
 /* ipad pro */
@@ -215,5 +221,14 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper:nth-last-child(2) .flyout-
     header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .container-menu-teaser,
     header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-wrapper.bmw-info .flyout-main-container .container-link-list {
         width: 100%;  
+    }
+
+    header.header-wrapper .nav-brand .menu-flyout-wrapper:nth-last-child(2) .flyout-main-container{
+        flex-wrap: wrap;
+        height: auto;
+        overflow-y: auto;
+        align-items: revert;
+        row-gap: 4rem;
+        max-height: calc(100vh - 149px);
     }
 }

--- a/blocks/menu-flyout/menu-flyout.css
+++ b/blocks/menu-flyout/menu-flyout.css
@@ -138,7 +138,7 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper:nth-last-child(2) .flyout-
     overflow-y: auto;
     align-items: revert;
     row-gap: 4rem;
-    max-height: calc(100vh - 249px);
+    max-height: calc(100vh - 15rem);
 }
 
 header.header-wrapper .nav-brand .menu-flyout-wrapper:nth-last-child(2) .flyout-main-container .flyout-link-list {
@@ -229,6 +229,6 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper:nth-last-child(2) .flyout-
         overflow-y: auto;
         align-items: revert;
         row-gap: 4rem;
-        max-height: calc(100vh - 149px);
+        max-height: calc(100vh - 9rem);
     }
 }


### PR DESCRIPTION
fixes: 
After clicking the 'Pronadite Online' or 'BMW Info' links, flyout opens up but header is missing

Test URLs:
- Before: https://main--metafox-sites--bmw-importer.hlx.page/
- After: https://feature-metafox-28-header--metafox-sites--bmw-importer.hlx.page/
