### PR TITLE
header flyout defects fixes

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1153,6 +1153,9 @@ header nav[aria-expanded="true"] .nav-brand.mobile-flyout .menu-flyout-wrapper .
     transform: scaleY(1);
     transition-delay: 0s, 0s;
     align-items: revert;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    max-width: 109.5rem !important;
   }
 
 }

--- a/blocks/menu-flyout/menu-flyout.css
+++ b/blocks/menu-flyout/menu-flyout.css
@@ -42,7 +42,7 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-
 header.header-wrapper .nav-brand .menu-flyout-wrapper .link-list-wrapper.vertical .link-list-detail li a {
     font-family: var(--fixed-font-family);
     font-size: 0.875rem;
-    color: var(--medium-text-color);
+    color: var(--light-text-color);
     line-height: 1.25rem;
     font-weight: 700;
     word-break: break-all;
@@ -55,6 +55,7 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .link-list-wrapper.vertica
 header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-container .flyout-menu-teaser .link-label a {
     align-items: center;
     display: inline-flex;
+    color: var(--light-text-color);
 }
 
 header.header-wrapper .nav-brand .menu-flyout-wrapper .link-list-wrapper.vertical .link-list-detail li a:hover,
@@ -83,12 +84,13 @@ header.header-wrapper .nav-brand .menu-flyout-wrapper .menu-flyout .flyout-main-
     width: auto;
     outline: transparent solid 1px;
     white-space: nowrap;
+    color: var(--light-text-color)
 }
 
 header.header-wrapper .nav-brand .menu-flyout-wrapper .link-list-wrapper.vertical .link-list-title {
     padding-right: 0;
     margin: 0 0 1rem;
-    color: var(--medium-text-color);
+    color: var(--light-text-color);
     font-size: 0.625rem;
     font-weight: 300;
     line-height: 0.75rem;


### PR DESCRIPTION
Fixes: 
Font color is not as expected for Header flyout link list title. It must be (38,38,38)
After clicking menu flyout, when we zoom in the screen the list of areas are not looking aligned as per live site

Test URLs:
- Before: https://main--metafox-sites--bmw-importer.hlx.page/
- After: https://feature-metafox-28-header--metafox-sites--bmw-importer.hlx.page/
