### PR TITLE
content-nav block corrected

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -683,24 +683,18 @@
         {
           "title": "Content Navigation",
           "id": "content-navigation",
-          "components": [
-            {
-              "title": "Content Navigation",
-              "id": "content-navigation",
-              "plugins": {
-                "xwalk": {
-                  "page": {
-                    "resourceType": "core/franklin/components/block/v1/block",
-                    "template": {
-                      "name": "Content Navigation",
-                      "model": "content-navigation",
-                      "filter": "content-navigation"
-                    }
-                  }
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Content Navigation",
+                  "model": "content-navigation",
+                  "filter": "content-navigation"
                 }
               }
             }
-          ]
+          }
         }
       ]
     },    


### PR DESCRIPTION
block level corrected.

Test URLs:
- Before:  https://main--metafox-sites--bmw-importer.hlx.page/
- After:  https://metafox-736-block-creation--metafox-sites--bmw-importer.hlx.page/test-pages/content-navigation
