### PR TITLE
fix: multi content gallery without tabs

### DIFF
--- a/blocks/multicontent-gallery/multicontent-gallery.js
+++ b/blocks/multicontent-gallery/multicontent-gallery.js
@@ -343,7 +343,7 @@ export default function decorate(block) {
 
   // loop through all children blocks
   [...panels].forEach((panel, index) => {
-    const [, content, , vidOrImg, , button] = panel.children;
+    const [content, vidOrImg, button] = panel.children;
 
     // hidding origin div so that in author page its not visible
     panel.classList.add('hidden');


### PR DESCRIPTION
Test with https://author-p132653-e1287758.adobeaemcloud.com/ui#/@bmwimportermarkets/aem/universal-editor/canvas/author-p132653-e1287758.adobeaemcloud.com/content/metafox/test-pages/index-copy/multicontent-gallery.html?ref=fix-multicontent-gal-without-tabs

Content needs to be published again.


Test URLs:
- Before: https://main--metafox-sites--bmw-Importer.hlx.live/test-pages/index-copy/multicontent-gallery
- After: https://fix-multicontent-gal-without-tabs--metafox-sites--bmw-Importer.hlx.live/test-pages/index-copy/multicontent-gallery
