### PR TITLE
analytics section added for section and flexible width section

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -279,6 +279,19 @@
         "name": "contentnavigation",
         "valueType": "boolean",
         "value": true
+      },
+      {
+        "component": "tab",
+        "label": "Analytics",
+        "name": "tab-analytics"
+      },
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "description": "Defines the name of the section for analytics. Please define the Section Name in English.",
+        "name": "analytis-label",
+        "value": "",
+        "label": "Section Label"
       }
     ]
   },
@@ -368,6 +381,19 @@
         "name": "contentnavigation",
         "valueType": "boolean",
         "value": true
+      },
+      {
+        "component": "tab",
+        "label": "Analytics",
+        "name": "tab-analytics"
+      },
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "description": "Defines the name of the section for analytics. Please define the Section Name in English.",
+        "name": "analytis-label",
+        "value": "",
+        "label": "Section Label"
       }
     ]
   },


### PR DESCRIPTION
Analytics Tabs added for the component like:
1) sections
2) flexible-width-section

Test URLs:
- Before: https://main--metafox-sites--bmw-importer.hlx.page/
- After:  https://author-p132653-e1287758.adobeaemcloud.com/ui#/@bmwimportermarkets/aem/universal-editor/canvas/author-p132653-e1287758.adobeaemcloud.com/content/metafox/masters/en/reference-content/content-navigation.html?ref=feature-metafox-1673-analytics
