### PR TITLE
correct label name

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -289,7 +289,7 @@
         "component": "text-input",
         "valueType": "string",
         "description": "Defines the name of the section for analytics. Please define the Section Name in English.",
-        "name": "analytis-label",
+        "name": "analytics-label",
         "value": "",
         "label": "Section Label"
       }
@@ -391,7 +391,7 @@
         "component": "text-input",
         "valueType": "string",
         "description": "Defines the name of the section for analytics. Please define the Section Name in English.",
-        "name": "analytis-label",
+        "name": "analytics-label",
         "value": "",
         "label": "Section Label"
       }
@@ -505,7 +505,7 @@
         "component": "text-input",
         "valueType": "string",
         "description": "Defines the name of the section for analytics. Please define the Section Name in English.",
-        "name": "analytis-label",
+        "name": "analytics-label",
         "value": "",
         "label": "Section Label"
       }


### PR DESCRIPTION
typo error fixed

Test URLs:
- Before:https://main--metafox-sites--bmw-importer.hlx.page/
- After:  https://feature-metafox-1673-analytics--metafox-sites--BMW-Importer.hlx.page/
