### PR TITLE
Content-nav analytics changes

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -1894,7 +1894,7 @@
 
       },
       {
-        "component":"select",
+        "component":"multiselect",
         "name":"analytics-button",
         "label":"Button/Link type", 
         "valueType": "string",
@@ -1912,6 +1912,27 @@
             "value": "Other"
           }          
         ]    
+      },
+      {
+        "component": "text-input",
+        "label": "Learn More",
+        "name": "learnMore",
+        "valueType": "string",
+        "condition": { "===": [{"var" : "analytics-button"}, "Other"] }
+      },
+      {
+        "component": "text-input",
+        "label": "Configure",
+        "name": "configure",
+        "valueType": "string",
+        "condition": { "===": [{"var" : "analytics-button"}, "Other"] }
+      },
+      {
+        "component": "text-input",
+        "label": "Technical-data",
+        "name": "hidden-text",
+        "valueType": "string",
+        "condition": { "===": [{"var" : "analytics-button"}, "Other"] }
       }
     ]
   },

--- a/component-models.json
+++ b/component-models.json
@@ -1929,8 +1929,8 @@
       },
       {
         "component": "text-input",
-        "label": "Technical-data",
-        "name": "hidden-text",
+        "label": "Technical Data",
+        "name": "Technical data",
         "valueType": "string",
         "condition": { "===": [{"var" : "analytics-button"}, "Other"] }
       }

--- a/component-models.json
+++ b/component-models.json
@@ -1914,26 +1914,27 @@
         ]    
       },
       {
-        "component": "text-input",
+        "component": "select",
         "label": "Learn More",
         "name": "learnMore",
         "valueType": "string",
-        "condition": { "===": [{"var" : "analytics-button"}, "Other"] }
-      },
-      {
-        "component": "text-input",
-        "label": "Configure",
-        "name": "configure",
-        "valueType": "string",
-        "condition": { "===": [{"var" : "analytics-button"}, "Other"] }
-      },
-      {
-        "component": "text-input",
-        "label": "Technical Data",
-        "name": "Technical data",
-        "valueType": "string",
-        "condition": { "===": [{"var" : "analytics-button"}, "Other"] }
+        "condition": { "===": [{"var" : "analytics-button"}, "Other"] },
+        "options": [
+          {
+            "name": "Learn More",
+            "value": "learnMore"
+          },
+          {
+            "name": "Downloa",
+            "value": "Download"
+          },
+          {
+            "name": "Other",
+            "value": "Other"
+          }          
+        ]
       }
+      
     ]
   },
   {

--- a/component-models.json
+++ b/component-models.json
@@ -1894,7 +1894,7 @@
 
       },
       {
-        "component":"multiselect",
+        "component":"select",
         "name":"analytics-button",
         "label":"Button/Link type", 
         "valueType": "string",

--- a/component-models.json
+++ b/component-models.json
@@ -1879,6 +1879,39 @@
             "value": "Money Button"
           }
         ]    
+      },
+      {
+        "component":"tab",
+        "name":"analytics-tab",
+        "label":"Analytics"
+
+      },
+      {
+        "component":"text-input",
+        "name":"analytics-label",
+        "label":"Analytics Label",
+        "valueType": " "
+
+      },
+      {
+        "component":"select",
+        "name":"analytics-button",
+        "label":"Button/Link type", 
+        "valueType": "string",
+        "options": [
+          {
+            "name": "Exit",
+            "value": "Exit"
+          },
+          {
+            "name": "Download",
+            "value": "Download"
+          },
+          {
+            "name": "Other",
+            "value": "Other"
+          }          
+        ]    
       }
     ]
   },

--- a/component-models.json
+++ b/component-models.json
@@ -1915,7 +1915,7 @@
       },
       {
         "component": "select",
-        "label": "Learn More",
+        "label": "Only if other is selected the following opotions should appear:",
         "name": "learnMore",
         "valueType": "string",
         "condition": { "===": [{"var" : "analytics-button"}, "Other"] },
@@ -1925,13 +1925,53 @@
             "value": "learnMore"
           },
           {
-            "name": "Downloa",
-            "value": "Download"
+            "name": "Configure",
+            "value": "Configure"
+          },
+          {
+            "name": "Technical Data",
+            "value": "Technical Data"
+          },
+          {
+            "name": "Options and Prices",
+            "value": "Options and Prices"
+          },
+          {
+            "name": "Vehicles in Stock",
+            "value": "Vehicles in Stock"
+          },
+          {
+            "name": "Request for Offer",
+            "value": "Request for Offer"
+          },
+          {
+            "name": "Sales and Service Network",
+            "value": "Sales and Service Network"
+          },
+          {
+            "name": "Test Drive",
+            "value": "Test Drive"
+          },
+          {
+            "name": "Newsletter Signup",
+            "value": "Newsletter Signup"
+          },
+          {
+            "name": "Contact",
+            "value": "Contact"
+          },
+          {
+            "name": "Search",
+            "value": "Search"
+          },
+          {
+            "name": "Show More / Show Less",
+            "value": "Show More / Show Less"
           },
           {
             "name": "Other",
             "value": "Other"
-          }          
+          }    
         ]
       }
       


### PR DESCRIPTION
For Content-navigation added analytics properties.

Test URLs:
- Before: https://main--metafox-sites--bmw-importer.hlx.page/
- After:  https://feature-metafox-1673-analytics--metafox-sites--BMW-Importer.hlx.page
