### PR TITLE
Feature/1906 tech data

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -1055,10 +1055,10 @@
                   "content_accordionView": "true",
                   "content_autoDataType": "h2",
                   "content_accordionViewType": "h3",
-                  "content_headlineAndText1Type": "h2",
-                  "content_headline1LinkType": "secondary",
-                  "content_headlineAndText2Type": "h2",
-                  "content_headline2LinkType": "secondary"
+                  "headline1_headlineAndText1Type": "h2",
+                  "headline1_headline1LinkType": "secondary",
+                  "headline2_headlineAndText2Type": "h2",
+                  "headline2_headline2LinkType": "secondary"
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -4794,70 +4794,68 @@
       {
         "component": "text-input",
         "valueType": "string",
-        "name": "content_headlineAndText1",
+        "name": "headline1_headlineAndText1",
         "label": "Headline and Text",
-        "value": "h2",
         "description": "Defines the headline and copy text to be displayed underneath the technical data table."        
       },
       {
         "component": "text",        
-        "name": "content_headlineAndText1Type",
+        "name": "headline1_headlineAndText1Type",
         "valueType": "string",
         "hidden": true
       },
       {
         "component": "text-input",
         "valueType": "string",
-        "name": "content_headline1Link",
+        "name": "headline1_headline1Link",
         "label": "Link",
         "description": "Defines the page to which the user will be directed to. Please add the full URL including https://"        
       },
       {
         "component": "text-input",
         "valueType": "string",
-        "name": "content_headline1LinkText",
+        "name": "headline1_headline1LinkText",
         "label": "Link Label",
         "description": "Defines the text to be displayed as the Link Button."        
       },
       {
         "component": "text-input",
         "valueType": "string",
-        "name": "content_headline1LinkType",
+        "name": "headline1_headline1LinkType",
         "label": "Link Label",
         "hidden": true        
       },
       {
         "component": "text-input",
         "valueType": "string",
-        "name": "content_headlineAndText2",
-        "label": "Headline and Text",
-        "value": "h2",
+        "name": "headline2_headlineAndText2",
+        "label": "Headline and Text",        
         "description": "Defines the headline and copy text to be displayed underneath the technical data table."        
       },
       {
         "component": "text",        
-        "name": "content_headlineAndText2Type",
+        "name": "headline2_headlineAndText2Type",
         "valueType": "string",
         "hidden": true
       },
       {
         "component": "text-input",
         "valueType": "string",
-        "name": "content_headline2Link",
+        "name": "headline2_headline2Link",
         "label": "Link",
         "description": "Defines the page to which the user will be directed to. Please add the full URL including https://"        
       },
       {
         "component": "text-input",
         "valueType": "string",
-        "name": "content_headline2LinkText",
+        "name": "headline2_headline2LinkText",
         "label": "Link Label",
         "description": "Defines the text to be displayed as the Link Button."        
       },
       {
         "component": "text-input",
         "valueType": "string",
-        "name": "content_headline2LinkType",
+        "name": "headline2_headline2LinkType",
         "label": "Link Label",
         "hidden": true        
       }


### PR DESCRIPTION
Technical data headline changes

Test URLs:

Before: https://main--{repo}--{owner}.hlx.live/
After: https://feature-1906-tech-data--metafox-sites--bmw-importer.hlx.page/en/reference-content/technical-data
